### PR TITLE
Update GitHub pages, min-payout flag & instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ Configuration options include:
 - secondsecret: your second secret or null if disabled
 - donations: a list of object (address: amount) for send static amount every payout, can be used for reserve & donations (change reserve_address to your reserve/donations address and change R to an integer or decimal number)
 - donationspercentage: a list of object (address: percentage) for send same percentage every payout
-- node: the shift node where you get forging info + API port (default: localhost:9305)
-- nodepay: the shift node used for payments + API port (default: localhost:9305)
+- node: the shift node where you get forging info + API port (mainnet: localhost:9305, testnet: localhost:9306, custom: IP:port)
+- nodepay: the shift node used for payments + API port (mainnet: localhost:9305, testnet: localhost:9306, custom: IP:port)
 - logfile: file where you want to write pending and sent amounts (default: poollogs.json)
 - feededuct: true if you want to subtract fees from user payouts (default: false)
 - private: true or false for private pool
@@ -27,7 +27,7 @@ Configuration options include:
 
 You can also edit docs/index.html and customize the webpage, or leave as is if not running webpage.
 
-## Setting it up & running it
+## Setting up & running the shift-pool script
 
 First clone the shift-pool repository: 
 
@@ -139,12 +139,10 @@ Payouts are not automatically uploaded to GitHub using this cronjob, you'll need
 
 In some DPOS, voters switch their voting weight from one delegate to another for receiving payout from multiple pools. A solution for that is the following flow:
 
-1. Run shiftpool.py every hour with --min-payout=1000000 (a very high minpayout, so no payouts will be done but the pending will be updated);
+1. Run shiftpool.py every hour with --min-payout=10000000000 (a very high minpayout, so no payouts will be done but the pending will be updated);
 2. Run shiftpool.py normally to broadcast the payments
 
-Running the shiftpool.py command in step 2 should only be done after forging another block (or several to be sure), otherwise it will not pick up any changes and not broadcast the payments. My advice would be setting the cronjob of step 1 to run every hour at half past, whilst setting the cronjob of step 2 to run once a day at a whole hour.
-
-Instead of setting commands, you can also set the cronjobs using these scripts: (1) prevent-poolhopping.sh && (2) pay.sh
+If no new forged blocks are discovered by the API request, shift-pool.py will exit automatically. You can set the commands as cronjobs to automate the above flow. Additionally, instead of setting commands, you can also set the cronjobs using these scripts: (1) prevent-poolhopping.sh && (2) pay.sh
 
 ## Command line usage
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Configuration options include:
 - whitelist: list of addresses to include in private pool
 - skip: a list of address to skip
 
-You can also edit docs/index.html and customize the webpage, or leave as is if not running webpage.
+You can also edit pages/index.html and customize the webpage, or leave as is if not running webpage.
 
 ## Setting up & running the shift-pool script
 
@@ -73,9 +73,9 @@ It produces a file "payments.sh" with all payments shell commands. Run this file
 
 ```bash payments.sh```
 
-The payments will be broadcasted (every 10 seconds). At the end you can move your generated poollogs.json to docs/poollogs.json:
+The payments will be broadcasted (every 10 seconds). At the end you can move your generated poollogs.json to pages/poollogs.json:
 
-```cp poollogs.json docs/poollogs.json```
+```cp poollogs.json pages/poollogs.json```
 
 ### Private pool
 If you want to run a private pool, you need to edit config.json and:
@@ -107,7 +107,7 @@ It is also possible to use GitHub as your pool front-end. First, fork this repos
 
 After that, follow the rest of the instructions exactly as described above. After completing the setup and running your payout, you can send the update to your Git repo:
 
-```git add docs/poollogs.json```
+```git add pages/poollogs.json```
 
 ```git commit -m "payouts update"```
 
@@ -117,7 +117,7 @@ Or run the following script and have those automated:
 
 ```bash pool-update.sh```
 
-To display the pool frontend, enable docs-site on GitHub repository settings. 
+To display the pool frontend, enable GitHub Pages on GitHub repository settings. 
 
 ## Batch mode
 
@@ -125,13 +125,13 @@ The script is also runnable by cron using the -y argument:
 
 ```python3 shiftpool.py -y```
 
-There is also a 'pay.sh' file which runs shiftpool.py, then payments.sh and copy the poollogs.json in the docs folder.
+There is also a 'pay.sh' file which runs shiftpool.py, then payments.sh and copy the poollogs.json in the pages folder.
 
 ## Cronjob to automate payouts
 
 Set this command as cronjob to automate payouts at chosen intervals:
 
-```cd shift-pool && python3 shiftpool.py -y && sleep 5 && bash payments.sh && sleep 5 && cp poollogs.json docs/poollogs.json```
+```cd shift-pool && python3 shiftpool.py -y && sleep 5 && bash payments.sh && sleep 5 && cp poollogs.json pages/poollogs.json```
 
 Payouts are not automatically uploaded to GitHub using this cronjob, you'll need to do that manually or using the pool-update.sh script.
 

--- a/pay.sh
+++ b/pay.sh
@@ -1,3 +1,3 @@
 python3 shiftpool.py -y
 bash payments.sh
-cp poollogs.json docs/poollogs.json
+cp poollogs.json pages/poollogs.json

--- a/pool-update.sh
+++ b/pool-update.sh
@@ -1,1 +1,1 @@
-git add docs/poollogs.json && git commit -m "Payouts update" && git push -u -f origin master
+git add pages/poollogs.json && git commit -m "Payouts update" && git push -u -f origin master

--- a/prevent-poolhopping.sh
+++ b/prevent-poolhopping.sh
@@ -1,1 +1,1 @@
-python3 shiftpool.py -y --min-payout=10000000
+python3 shiftpool.py -y --min-payout=10000000000


### PR DESCRIPTION
Update docs-site references to GitHub Pages
Update min-payout flag
Update instructions
- Include testnet & custom configuration for 'node' & 'nodepay'
- Rewrite 'Avoid vote hoppers' to facilitate new sys.exit() if no rewards are found
